### PR TITLE
build: Update to obelisk 0.41.3

### DIFF
--- a/dev-deps.txt
+++ b/dev-deps.txt
@@ -4,7 +4,7 @@ cargo generate 0.23.9
 cargo-insta 1.48.0
 cargo-nextest 0.9.143
 just 1.58.0
-obelisk 0.41.2
+obelisk 0.41.3
 pkg-config 0.29.2
 rustc 1.97.1 (8bab26f4f 2026-07-14)
 wasm-tools 1.255.0

--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786904639,
-        "narHash": "sha256-FgwUb/dlch2BlxbLAQI+JoyIOZohPXWHRd4pdNTbuR8=",
+        "lastModified": 1787312112,
+        "narHash": "sha256-FdYfroyAFnTvxc1qj+yUUJofOu7qRJpQM15PvcOTikM=",
         "owner": "obeli-sk",
         "repo": "obelisk",
-        "rev": "2e8ef9e29dfb6ff76d33080a98007a97d6329353",
+        "rev": "93c94f550745ffabe5a166f1185573995ccbec28",
         "type": "github"
       },
       "original": {

--- a/scripts/check-wit-deps.sh
+++ b/scripts/check-wit-deps.sh
@@ -3,5 +3,4 @@
 set -exuo pipefail
 cd "$(dirname "$0")/.."
 
-rm -rf wit/deps/obelisk_*
-obelisk generate wit-deps --deployment obelisk-external.toml wit/deps --force
+obelisk generate wit-deps --deployment obelisk-external.toml wit/deps --force --prune


### PR DESCRIPTION
Use the new `obelisk generate wit-deps --prune` flag in check-wit-deps.sh
instead of manually removing obelisk_* dirs before regenerating.
